### PR TITLE
feat: BasePluginConfig.Update() return a update state & backup overriding configs

### DIFF
--- a/CSSharpUtils/Extensions/ConfigExtensions.cs
+++ b/CSSharpUtils/Extensions/ConfigExtensions.cs
@@ -25,6 +25,7 @@ public static class ConfigExtensions
     /// <typeparam name="T">The type of the configuration object, must inherit from BasePluginConfig.</typeparam>
     /// <param name="config">The configuration object to update and serialize.</param>
     /// <param name="backup">Should a backup file be created. default: true</param>
+    /// <param name="checkVersion">Checks and stops overwriting if configs are the same version. default: true</param>
     /// <returns><c>true</c> if the config is updated; otherwise, <c>false</c>.</returns>
     public static bool Update<T>(this T config, bool backup = true, bool checkVersion = true) where T : BasePluginConfig, new()
     {

--- a/CSSharpUtils/Extensions/ConfigExtensions.cs
+++ b/CSSharpUtils/Extensions/ConfigExtensions.cs
@@ -24,8 +24,9 @@ public static class ConfigExtensions
     /// </summary>
     /// <typeparam name="T">The type of the configuration object, must inherit from BasePluginConfig.</typeparam>
     /// <param name="config">The configuration object to update and serialize.</param>
+    /// <param name="checkVersion">Checks if the new config version is higher then the one saved.</param>
     /// <returns><c>true</c> if the config is updated; otherwise, <c>false</c>.</returns>
-    public static bool Update<T>(this T config) where T : BasePluginConfig, new()
+    public static bool Update<T>(this T config, bool checkVersion = true) where T : BasePluginConfig, new()
     {
         // get config path
         var configPath = GetConfigPath(Assembly.GetCallingAssembly());
@@ -38,7 +39,7 @@ public static class ConfigExtensions
         var newCfgVersion = new T().Version;
 
         // loaded config is up-to-date
-        if (config.Version == newCfgVersion)
+        if (checkVersion && config.Version == newCfgVersion)
             return false;
 
         // get counter of backup file

--- a/CSSharpUtils/Extensions/ConfigExtensions.cs
+++ b/CSSharpUtils/Extensions/ConfigExtensions.cs
@@ -15,7 +15,7 @@ public static class ConfigExtensions
 
     // Defines the path to the configuration file, based on the game directory and assembly name.
     public static readonly string ConfigPath =
-        $"{Server.GameDirectory}/csgo/addons/counterstrikesharp/configs/plugins/{AssemblyName}/{AssemblyName}.json";
+        $"{Server.GameDirectory}/csgo/addons/counterstrikesharp/configs/plugins/{AssemblyName}/{AssemblyName}";
 
     // Specifies the options for JSON serialization, including indentation for readability.
     private static readonly JsonSerializerOptions WriteSerializerOptions = new() { WriteIndented = true };
@@ -28,6 +28,7 @@ public static class ConfigExtensions
     /// Updates the version of the provided configuration object and serializes it back to JSON.
     /// This method ensures that the configuration file reflects the most recent version,
     /// including all properties of the configuration object, even those not initially set.
+    /// Also backs up the current configuration file before updating it.
     /// </summary>
     /// <typeparam name="T">The type of the configuration object, must inherit from BasePluginConfig.</typeparam>
     /// <param name="config">The configuration object to update and serialize.</param>
@@ -40,6 +41,12 @@ public static class ConfigExtensions
         // loaded config is up-to-date
         if (config.Version == newCfgVersion)
             return false;
+
+        // get counter of backup file
+        var backupCount = GetBackupCount();
+
+        // create a backup of the current config
+        File.Copy($"{ConfigPath}.json", $"{ConfigPath}-{backupCount}.bak", true);
 
         // update the version
         config.Version = newCfgVersion;
@@ -61,9 +68,19 @@ public static class ConfigExtensions
     public static T Reload<T>(this T config) where T : BasePluginConfig, new()
     {
         // read the configuration file content
-        var configContent = File.ReadAllText(ConfigPath);
+        var configContent = File.ReadAllText($"{ConfigPath}.json");
 
         // deserialize the configuration content back to the object
         return JsonSerializer.Deserialize<T>(configContent, ReadSerializerOptions)!;
+    }
+
+    private static int GetBackupCount()
+    {
+        var counter = 0;
+
+        while (File.Exists($"{ConfigPath}-{counter}.bak"))
+            counter++;
+
+        return counter;
     }
 }

--- a/CSSharpUtils/Extensions/ConfigExtensions.cs
+++ b/CSSharpUtils/Extensions/ConfigExtensions.cs
@@ -27,14 +27,12 @@ public static class ConfigExtensions
     /// <returns><c>true</c> if the config is updated; otherwise, <c>false</c>.</returns>
     public static bool Update<T>(this T config) where T : BasePluginConfig, new()
     {
-        // get the name of the calling assembly
-        var assemblyName = Assembly.GetCallingAssembly().GetName().Name ?? null;
-        
-        // check if the assembly name is null
-        if (assemblyName == null)
-            return false;
+        // get config path
+        var configPath = GetConfigPath(Assembly.GetCallingAssembly());
 
-        var configPath = $"{Server.GameDirectory}/csgo/addons/counterstrikesharp/configs/plugins/{assemblyName}/{assemblyName}";
+        // check if valid config path
+        if (configPath == null)
+            return false;
 
         // get newest config version
         var newCfgVersion = new T().Version;
@@ -68,20 +66,24 @@ public static class ConfigExtensions
     /// </remarks>
     public static T Reload<T>(this T config) where T : BasePluginConfig, new()
     {
-        // get the name of the calling assembly
-        var assemblyName = Assembly.GetCallingAssembly().GetName().Name ?? null;
+        // get config path
+        var configPath = GetConfigPath(Assembly.GetCallingAssembly());
 
-        // check if the assembly name is null
-        if (assemblyName == null)
+        // check if valid config path
+        if (configPath == null)
             return new();
-
-        var configPath = $"{Server.GameDirectory}/csgo/addons/counterstrikesharp/configs/plugins/{assemblyName}/{assemblyName}";
 
         // read the configuration file content
         var configContent = File.ReadAllText($"{configPath}.json");
 
         // deserialize the configuration content back to the object
         return JsonSerializer.Deserialize<T>(configContent, ReadSerializerOptions)!;
+    }
+
+    private static string? GetConfigPath(Assembly callingAssembly)
+    {
+        var assemblyName = callingAssembly.GetName().Name ?? null;
+        return assemblyName == null ? null : $"{Server.GameDirectory}/csgo/addons/counterstrikesharp/configs/plugins/{assemblyName}/{assemblyName}";
     }
 
     private static int GetBackupCount(string configPath)

--- a/CSSharpUtils/Extensions/ConfigExtensions.cs
+++ b/CSSharpUtils/Extensions/ConfigExtensions.cs
@@ -22,7 +22,7 @@ public static class ConfigExtensions
     
     // Specifies the options for JSON deserialization.
     private static readonly JsonSerializerOptions ReadSerializerOptions = new() { ReadCommentHandling = JsonCommentHandling.Skip };
-    
+
 
     /// <summary>
     /// Updates the version of the provided configuration object and serializes it back to JSON.
@@ -31,14 +31,15 @@ public static class ConfigExtensions
     /// </summary>
     /// <typeparam name="T">The type of the configuration object, must inherit from BasePluginConfig.</typeparam>
     /// <param name="config">The configuration object to update and serialize.</param>
-    public static void Update<T>(this T config) where T : BasePluginConfig, new()
+    /// <returns><c>true</c> if the config is updated; otherwise, <c>false</c>.</returns>
+    public static bool Update<T>(this T config) where T : BasePluginConfig, new()
     {
         // get newest config version
         var newCfgVersion = new T().Version;
 
         // loaded config is up-to-date
         if (config.Version == newCfgVersion)
-            return;
+            return false;
 
         // update the version
         config.Version = newCfgVersion;
@@ -46,6 +47,7 @@ public static class ConfigExtensions
         // serialize the updated config back to json
         var updatedJsonContent = JsonSerializer.Serialize(config, WriteSerializerOptions);
         File.WriteAllText(ConfigPath, updatedJsonContent);
+        return true;
     }
 
     /// <summary>

--- a/CSSharpUtils/Utils/ChatUtils.cs
+++ b/CSSharpUtils/Utils/ChatUtils.cs
@@ -48,4 +48,15 @@ public static class ChatUtils
         foreach (var player in teamPlayers)
             player.PrintToChat(message);
     }
+
+    /// <summary>
+    /// Sends a chat message to all players.
+    /// </summary>
+    /// <param name="message">The message to send.</param>
+    public static void PrintToAll(string message)
+    {
+        var players = Utilities.GetPlayers();
+        foreach (var player in players)
+            player.PrintToChat(message);
+    }
 }

--- a/README.MD
+++ b/README.MD
@@ -24,14 +24,14 @@ Run `dotnet add package CSSharpUtils` or download the latest release from the [r
 ```csharp
 using CSSharpUtils.Extensions;
 
-// updates the config file on disk if the version is outdated
-config.Update();
+// updates the config file on disk, backup = true creates a backup, checkVersion = true stops overwriting if configs are the same version
+config.Update(backup: true, checkVersion: true);
 
 // reloads the config file from disk
 OnConfigParsed(new MyPluginConfig().Reload());
 
 // get the plugin config path
-Console.WriteLine($"Config path: {ConfigExtensions.ConfigPath}");
+Console.WriteLine($"Config path: {new MyPluginConfig().ConfigPath()}");
 ```
 
 ### Player
@@ -93,6 +93,9 @@ player.PrintToChat(ChatUtils.CleanMessage(message)); // will print "Hello World"
 
 // Send a message to all players in the Terrorist team
 ChatUtils.PrintToTeam(CsTeam.Terrorist, "This message is for Terrorists only.");
+
+// Send a message to all players
+ChatUtils.PrintToAll("This message is for all players.")
 ```
 
 ### Team


### PR DESCRIPTION
A small change to the method that returns a boolean if the config file was updated or not, useful to create .bak files of config files which could be incorporated into the whole update system itself